### PR TITLE
fix: don't post to slack for drafts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,14 +12,14 @@ if (!SLACK_BOT_TOKEN) {
 const slack = new WebClient(SLACK_BOT_TOKEN)
 
 export = (app: Probot) => {
-  app.on("pull_request.labeled", async (context) => {
-    if (context.payload.label?.id === API_REVIEW_REQUESTED_LABEL_ID) {
-      const escapedTitle = context.payload.pull_request.title.replace(/[&<>]/g, (x) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[x]!))
+  app.on("pull_request.labeled", async ({ payload }) => {
+    if (payload.label?.id === API_REVIEW_REQUESTED_LABEL_ID && !payload.pull_request.draft) {
+      const escapedTitle = payload.pull_request.title.replace(/[&<>]/g, (x) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[x]!))
       slack.chat.postMessage({
         channel: '#wg-api',
         unfurl_links: false,
         text: `Hey <!subteam^SNSJW1BA9>! Just letting you know that the following PR needs API review:\n`+
-          `*<${context.payload.pull_request._links.html.href}|${escapedTitle} (#${context.payload.pull_request.number})>*`
+          `*<${payload.pull_request._links.html.href}|${escapedTitle} (#${payload.pull_request.number})>*`
       })
     }
   });


### PR DESCRIPTION
Avoid posting to Slack new notices for PRs with `api-review-requested` if they're drafts. The remind function already filters out drafts, and so we should here too.

Seen https://github.com/electron/electron/pull/35310.