### PR TITLE
feat: add tag for maintainer and first time contributors

### DIFF
--- a/src/remind.ts
+++ b/src/remind.ts
@@ -170,7 +170,7 @@ const formatPRListItem = (item: IssueOrPullRequest, activity?: PullRequestActivi
     isMaintainer && ':pr-maintainer:',
     isFirstTimeContributor && ':pr-first-time-contributor:',
   ].filter(Boolean) as string[];
-  const tagsLabel = tags.length ? ` ${tags.join(' ')}` : '';
+  const tagsLabel = tags.length ? `${tags.join(' ')} ` : '';
 
   const createdAt = new Date(item.created_at);
   const reviewLabel = activity
@@ -179,7 +179,7 @@ const formatPRListItem = (item: IssueOrPullRequest, activity?: PullRequestActivi
       )})`
     : `Awaiting review since ${timeAgo(createdAt)} (${formatSlackDate(createdAt)})`;
 
-  return `• *<${item.html_url}|${escapeTitle(item.title)} (#${item.number})>*${tagsLabel}
+  return `• ${tagsLabel}*<${item.html_url}|${escapeTitle(item.title)} (#${item.number})>*
     _${reviewLabel}_`;
 };
 

--- a/src/remind.ts
+++ b/src/remind.ts
@@ -163,9 +163,13 @@ const formatSlackDate = (d: Date) => {
 };
 
 const formatPRListItem = (item: IssueOrPullRequest, activity?: PullRequestActivity) => {
-  const firstTimeContributor = item.author_association === 'FIRST_TIME_CONTRIBUTOR';
+  const isMaintainer = item.author_association === 'MEMBER' || item.author_association === 'OWNER';
+  const isFirstTimeContributor = item.author_association === 'FIRST_TIME_CONTRIBUTOR';
 
-  const tags = [firstTimeContributor && ':first-time-contributor:'].filter(Boolean) as string[];
+  const tags = [
+    isMaintainer && ':pr-maintainer:',
+    isFirstTimeContributor && ':pr-first-time-contributor:',
+  ].filter(Boolean) as string[];
   const tagsLabel = tags.length ? ` ${tags.join(' ')}` : '';
 
   const createdAt = new Date(item.created_at);

--- a/src/remind.ts
+++ b/src/remind.ts
@@ -163,6 +163,11 @@ const formatSlackDate = (d: Date) => {
 };
 
 const formatPRListItem = (item: IssueOrPullRequest, activity?: PullRequestActivity) => {
+  const firstTimeContributor = item.author_association === 'FIRST_TIME_CONTRIBUTOR';
+
+  const tags = [firstTimeContributor && ':first-time-contributor:'].filter(Boolean) as string[];
+  const tagsLabel = tags.length ? ` ${tags.join(' ')}` : '';
+
   const createdAt = new Date(item.created_at);
   const reviewLabel = activity
     ? `Last reviewed by @${activity.user?.login} ${timeAgo(activity.created_at)} (${formatSlackDate(
@@ -170,9 +175,8 @@ const formatPRListItem = (item: IssueOrPullRequest, activity?: PullRequestActivi
       )})`
     : `Awaiting review since ${timeAgo(createdAt)} (${formatSlackDate(createdAt)})`;
 
-  return `• *<${item.html_url}|${escapeTitle(item.title)} (#${
-    item.number
-  })>*\n    _${reviewLabel}_`;
+  return `• *<${item.html_url}|${escapeTitle(item.title)} (#${item.number})>*${tagsLabel}
+    _${reviewLabel}_`;
 };
 
 async function main() {

--- a/src/remind.ts
+++ b/src/remind.ts
@@ -163,14 +163,13 @@ const formatSlackDate = (d: Date) => {
 };
 
 const formatPRListItem = (item: IssueOrPullRequest, activity?: PullRequestActivity) => {
-  const isMaintainer = item.author_association === 'MEMBER' || item.author_association === 'OWNER';
-  const isFirstTimeContributor = item.author_association === 'FIRST_TIME_CONTRIBUTOR';
-
   const tags = [
-    isMaintainer && ':pr-maintainer:',
-    isFirstTimeContributor && ':pr-first-time-contributor:',
+    item.author_association === 'CONTRIBUTOR' && ':pr-contributor:',
+    item.author_association === 'FIRST_TIME_CONTRIBUTOR' && ':pr-first-time-contributor:',
   ].filter(Boolean) as string[];
   const tagsLabel = tags.length ? `${tags.join(' ')} ` : '';
+
+  const titleLabel = `*<${item.html_url}|${escapeTitle(item.title)} (#${item.number})>*`;
 
   const createdAt = new Date(item.created_at);
   const reviewLabel = activity
@@ -179,7 +178,7 @@ const formatPRListItem = (item: IssueOrPullRequest, activity?: PullRequestActivi
       )})`
     : `Awaiting review since ${timeAgo(createdAt)} (${formatSlackDate(createdAt)})`;
 
-  return `• ${tagsLabel}*<${item.html_url}|${escapeTitle(item.title)} (#${item.number})>*
+  return `• ${tagsLabel}${titleLabel}
     _${reviewLabel}_`;
 };
 


### PR DESCRIPTION
Adds tags to indicate whether a PR is by a maintainer or first time contributor. These are just alias emojis which are customizable in the workspace.

🔰 is a common bumper sticker seen in Japan for beginner drivers, the [shoshinsha mark](https://en.wikipedia.org/wiki/Shoshinsha_mark). Open to other ideas here :)

Debating whether or not to keep the maintainer tag and only highlight first time contributors.

<img width="634" alt="Screenshot 2024-08-03 at 11 26 39 AM" src="https://github.com/user-attachments/assets/1706c65e-5318-4c84-867f-51ca8cef37cc">
