### PR TITLE
Add Procfile for Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yarn start
+web: HOST=0.0.0.0 yarn start


### PR DESCRIPTION
## Summary
This change adds a Procfile to enable deployment on Heroku, specifying how the application should be started in a production environment.

## Key Changes
- Added `Procfile` with a web process that starts the application with `yarn start` and binds to all network interfaces (`HOST=0.0.0.0`)

## Implementation Details
The Procfile configures the web dyno to listen on `0.0.0.0` instead of the default localhost, which is necessary for the application to be accessible when deployed on Heroku's containerized infrastructure.

https://claude.ai/code/session_01C4TYz3cx1L3CG7ji2MUSwM